### PR TITLE
Handle Duplicate Messages

### DIFF
--- a/Dalamud.DiscordBridge/Configuration.cs
+++ b/Dalamud.DiscordBridge/Configuration.cs
@@ -11,7 +11,7 @@ namespace Dalamud.DiscordBridge
     {
         public int Version { get; set; }
 
-        public long DuplicateCheckMS { get; set; } = 0;
+        public long DuplicateCheckMS { get; set; } = 5000;
 
         [JsonIgnore] private DalamudPluginInterface pluginInterface;
 

--- a/Dalamud.DiscordBridge/ContentParser.cs
+++ b/Dalamud.DiscordBridge/ContentParser.cs
@@ -1,0 +1,57 @@
+using System.Text.RegularExpressions;
+using Dalamud.Utility;
+
+namespace Dalamud.DiscordBridge
+{
+    /// <summary>
+    /// Parses a content string so that messages received externally can be compared.
+    /// </summary>
+    public class ContentParser
+    {
+        /// <summary>
+        /// Construct a <see cref="ContentParser"/>, parsing the given content string.
+        /// </summary>
+        /// <param name="content">The content string to parse.</param>
+        public ContentParser(string content)
+        {
+            match = Parse.Match(content);
+        }
+
+        /// <summary>
+        /// The user-defined prefix for the slug.
+        /// </summary>
+        public string Prefix => match.Groups[PrefixGroup].Value;
+        
+        /// <summary>
+        /// The slug for the chat kind.
+        /// </summary>
+        public string Slug => match.Groups[SlugGroup].Value;
+        
+        /// <summary>
+        /// The relevant text from the in-game chat line.
+        /// </summary>
+        public string Text => match.Groups[TextGroup].Value;
+
+        /// <summary>
+        /// Parse the text from a content string.
+        /// </summary>
+        /// <param name="content">The content string to parse.</param>
+        /// <returns>The relevant text from the in-game chat line.</returns>
+        public static string ParseText(string content)
+        {
+            var contentParser = new ContentParser(content);
+
+            string result = contentParser.Text;
+            
+            return result.IsNullOrEmpty() ? content : result;
+        }
+        
+        private const string PrefixGroup = "prefix";
+        private const string SlugGroup = "slug";
+        private const string TextGroup = "text";
+        
+        private static readonly Regex Parse = new(@$"(?'{PrefixGroup}'.*)\*\*\[(?'{SlugGroup}'.+)\]\*\* (?'{TextGroup}'.+)");
+
+        private readonly Match match;
+    }
+}

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -946,17 +946,13 @@ namespace Dalamud.DiscordBridge
                 {
                     PluginLog.Error("Could not find channel {0} for {1}", channelConfig.Key, chatType);
 
-                    // There is a specific circumstance where an exception within SendChatEvent() will cause GetChannel()
-                    // to temporarily no result (not found) which then results in configurations for multiple channels
-                    // being cleared below.
+                    var channelConfigs = this.plugin.Config.ChannelConfigs;
+                    channelConfigs.Remove(channelConfig.Key);
+                    this.plugin.Config.ChannelConfigs = channelConfigs;
 
-                    // Disabled the following to prevent losing channel configuration.
-                    // var channelConfigs = this.plugin.Config.ChannelConfigs;
-                    // channelConfigs.Remove(channelConfig.Key);
-                    // this.plugin.Config.ChannelConfigs = channelConfigs;
-                    //
-                    // PluginLog.Log("Removing channel {0}'s config because it no longer exists or cannot be accessed.", channelConfig.Key);
-                    // this.plugin.Config.Save();
+
+                    PluginLog.Log("Removing channel {0}'s config because it no longer exists or cannot be accessed.", channelConfig.Key);
+                    this.plugin.Config.Save();
                     
                     continue;
                 }

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -111,7 +111,7 @@ namespace Dalamud.DiscordBridge
             this.socketClient.Ready += SocketClientOnReady;
             this.socketClient.MessageReceived += SocketClientOnMessageReceived;
             
-            duplicateFilter = new DuplicateFilter(socketClient);
+            this.duplicateFilter = new DuplicateFilter(this.plugin, this.socketClient);
         }
 
         public async Task Start()

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -146,10 +146,10 @@ namespace Dalamud.DiscordBridge
 
         private async Task SocketClientOnMessageReceived(SocketMessage message)
         {
-	        if (message.Channel is SocketChannel socketChannel)
-	        {
-		        await Dedupe(socketChannel);
-	        }
+            if (message.Channel is SocketChannel socketChannel)
+            {
+                await Dedupe(socketChannel);
+            }
 
             if (message.Author.IsBot || message.Author.IsWebhook)
                 return;
@@ -898,92 +898,92 @@ namespace Dalamud.DiscordBridge
 
         private async Task Dedupe(SocketChannel socketChannel)
         {
-	        if (socketChannel is not SocketTextChannel socketTextChannel)
-	        {
-		        return;
-	        }
+            if (socketChannel is not SocketTextChannel socketTextChannel)
+            {
+                return;
+            }
 
-	        var cachedMessages = socketTextChannel.GetCachedMessages();
+            var cachedMessages = socketTextChannel.GetCachedMessages();
 
-	        var recentMessages = cachedMessages.Where(m => GetElapsedMs(m) < 10000);
-	        var socketMessages = recentMessages as SocketMessage[] ?? recentMessages.ToArray();
-	        var content = socketMessages.Select(m => m.Content);
+            var recentMessages = cachedMessages.Where(m => GetElapsedMs(m) < 10000);
+            var socketMessages = recentMessages as SocketMessage[] ?? recentMessages.ToArray();
+            var content = socketMessages.Select(m => m.Content);
 
-	        PluginLog.LogInformation($"Total: {cachedMessages.Count()}");
-	        PluginLog.LogInformation($"Recent: {socketMessages.Count()}");
-	        PluginLog.LogInformation($"Content: {string.Join(", ", content)}");
+            PluginLog.LogInformation($"Total: {cachedMessages.Count()}");
+            PluginLog.LogInformation($"Recent: {socketMessages.Count()}");
+            PluginLog.LogInformation($"Content: {string.Join(", ", content)}");
 
-	        for (var i = 0; i < socketMessages.Length; i++)
-	        {
-		        var recent = socketMessages[i];
+            for (var i = 0; i < socketMessages.Length; i++)
+            {
+                var recent = socketMessages[i];
 
-		        for (var j = 0; j < socketMessages.Length; j++)
-		        {
-			        if (i != j)
-			        {
-				        var other = socketMessages[j];
+                for (var j = 0; j < socketMessages.Length; j++)
+                {
+                    if (i != j)
+                    {
+                        var other = socketMessages[j];
 
-				        if (IsDuplicate(recent, other))
-				        {
-					        await DeleteMostRecent(recent, other);
-				        }
-			        }
-		        }
-	        }
+                        if (IsDuplicate(recent, other))
+                        {
+                            await DeleteMostRecent(recent, other);
+                        }
+                    }
+                }
+            }
         }
 
         private static long GetElapsedMs(SocketMessage message)
         {
-	        return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - message.Timestamp.ToUnixTimeMilliseconds();
+            return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - message.Timestamp.ToUnixTimeMilliseconds();
         }
 
         private async Task DeleteMostRecent(SocketMessage recent, SocketMessage other)
         {
-	        if (recent.Timestamp > other.Timestamp)
-	        {
-		        await TryDeleteAsync(recent);
-	        }
-	        else
-	        {
-		        await TryDeleteAsync(other);
-	        }
+            if (recent.Timestamp > other.Timestamp)
+            {
+                await TryDeleteAsync(recent);
+            }
+            else
+            {
+                await TryDeleteAsync(other);
+            }
         }
 
         private static async Task TryDeleteAsync(SocketMessage message)
         {
-	        PluginLog.LogInformation($"[IN TESTING]\n TRY DELETE: ({message.Author.Username}) {message.Content}");
+            PluginLog.LogInformation($"[IN TESTING]\n TRY DELETE: ({message.Author.Username}) {message.Content}");
 
-	        // if (message.Author.IsBot)
-	        // {
-		       //  PluginLog.LogInformation($"AUTHOR IS BOT");
-		       //  return;
-	        // }
+            // if (message.Author.IsBot)
+            // {
+               //  PluginLog.LogInformation($"AUTHOR IS BOT");
+               //  return;
+            // }
 
-	        try
-	        {
-		        await message.DeleteAsync();
-	        }
-	        catch (Discord.Net.HttpException)
-	        {
-		        PluginLog.LogInformation($"Message could not be deleted");
-	        }
+            try
+            {
+                await message.DeleteAsync();
+            }
+            catch (Discord.Net.HttpException)
+            {
+                PluginLog.LogInformation($"Message could not be deleted");
+            }
         }
 
         private bool IsDuplicate(SocketMessage recent, SocketMessage other)
         {
-	        string left = recent.Content;
-	        string right = other.Content;
+            string left = recent.Content;
+            string right = other.Content;
 
-	        bool notEmptyString = !(recent.Content.IsNullOrEmpty() && other.Content.IsNullOrEmpty());
+            bool notEmptyString = !(recent.Content.IsNullOrEmpty() && other.Content.IsNullOrEmpty());
 
-	        bool bothWebhook = recent.Author.IsWebhook && other.Author.IsWebhook;
+            bool bothWebhook = recent.Author.IsWebhook && other.Author.IsWebhook;
 
-	        bool sameUser = recent.Author.Username == other.Author.Username;
-	        //bool sameUser = true;
+            bool sameUser = recent.Author.Username == other.Author.Username;
+            //bool sameUser = true;
 
-	        bool differentId = recent.Id != other.Id;
+            bool differentId = recent.Id != other.Id;
 
-	        return notEmptyString && bothWebhook && sameUser && differentId && (left.Contains(right) || right.Contains(left));
+            return notEmptyString && bothWebhook && sameUser && differentId && (left.Contains(right) || right.Contains(left));
         }
 
         public async Task SendContentFinderEvent(QueuedContentFinderEvent cfEvent)

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -152,9 +152,10 @@ namespace Dalamud.DiscordBridge
         {
             //DEDUPE: call dedupe
             //LogDedupe("Message received");
-            if (message.Channel is SocketChannel socketChannel)
+            duplicateFilter.Add(message);
+            //if (message.Channel is SocketChannel socketChannel)
             {
-                await duplicateFilter.Dedupe(socketChannel);
+                await duplicateFilter.Dedupe();
             }
 
             if (message.Author.IsBot || message.Author.IsWebhook)
@@ -862,7 +863,7 @@ namespace Dalamud.DiscordBridge
                     continue;
                 }
 
-                if (duplicateFilter.IsRecentlySent(displayName, chatText: message, socketChannel))
+                if (duplicateFilter.IsRecentlySent(displayName, chatText: message))
                 {
                     return;
                 }

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -848,20 +848,24 @@ namespace Dalamud.DiscordBridge
                 {
                     PluginLog.Error("Could not find channel {0} for {1}", channelConfig.Key, chatType);
 
-                    var channelConfigs = this.plugin.Config.ChannelConfigs;
-                    channelConfigs.Remove(channelConfig.Key);
-                    this.plugin.Config.ChannelConfigs = channelConfigs;
+                    // There is a specific circumstance where an exception within SendChatEvent() will cause GetChannel()
+                    // to temporarily no result (not found) which then results in configurations for multiple channels
+                    // being cleared below.
 
-
-                    PluginLog.Log("Removing channel {0}'s config because it no longer exists or cannot be accessed.", channelConfig.Key);
-                    this.plugin.Config.Save();
+                    // Disabled the following to prevent losing channel configuration.
+                    // var channelConfigs = this.plugin.Config.ChannelConfigs;
+                    // channelConfigs.Remove(channelConfig.Key);
+                    // this.plugin.Config.ChannelConfigs = channelConfigs;
+                    //
+                    // PluginLog.Log("Removing channel {0}'s config because it no longer exists or cannot be accessed.", channelConfig.Key);
+                    // this.plugin.Config.Save();
                     
                     continue;
                 }
 
                 if (duplicateFilter.CheckAlreadySent(socketChannel, slug: chatTypeText, displayName, chatText: message))
                 {
-                    return;
+                    continue;
                 }
 
                 var webhookClient = await GetOrCreateWebhookClient(socketChannel);
@@ -871,8 +875,6 @@ namespace Dalamud.DiscordBridge
                     messageContent,username: displayName, avatarUrl: avatarUrl, 
                     allowedMentions: new AllowedMentions(AllowedMentionTypes.Roles | AllowedMentionTypes.Users | AllowedMentionTypes.None)
                 );
-                
-                PluginLog.LogVerbose($"Sent message:\n Channel: {socketChannel}\n Display Name: {displayName}\n Content: {messageContent}");
             }
         }
 

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -150,13 +150,9 @@ namespace Dalamud.DiscordBridge
 
         private async Task SocketClientOnMessageReceived(SocketMessage message)
         {
-            //DEDUPE: call dedupe
-            //LogDedupe("Message received");
             duplicateFilter.Add(message);
-            //if (message.Channel is SocketChannel socketChannel)
-            {
-                await duplicateFilter.Dedupe();
-            }
+            
+            await duplicateFilter.Dedupe();
 
             if (message.Author.IsBot || message.Author.IsWebhook)
                 return;

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -99,7 +99,6 @@ namespace Dalamud.DiscordBridge
                 .ToArray(); // Convert to array to avoid multiple enumeration below.
 
             // Holds deleted messages so that they can be removed from recents later.
-            //todo Since this function has been refactored, this set may no longer be necessary
             var deleted = new HashSet<SocketMessage>();
             
             // Compare every message to every other message to check for duplicates.

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 using Discord.WebSocket;
@@ -142,8 +141,8 @@ namespace Dalamud.DiscordBridge
         {
             try
             {
-                //await message.AddReactionAsync(new Emoji("💥"));
                 await message.DeleteAsync();
+                //await message.AddReactionAsync(new Emoji("💥")); // useful for testing
                 
                 PluginLog.LogVerbose($"[FILTER]\n[DELETED]\n CHANNEL: {message.Channel}\n NAME: {message.Author.Username}\n CONTENT: {message.Content}");
                 

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Dalamud.DiscordBridge.Model;
+using Dalamud.DiscordBridge.XivApi;
+using Dalamud.Game.Text;
+using Dalamud.Logging;
+using Dalamud.Utility;
+using Discord;
+using Discord.Net.Providers.WS4Net;
+using Discord.Webhook;
+using Discord.WebSocket;
+using Lumina.Text;
+using NetStone;
+using NetStone.Model.Parseables.Character;
+using NetStone.Model.Parseables.Search.Character;
+using NetStone.Search.Character;
+
+namespace Dalamud.DiscordBridge
+{
+    public class DuplicateFilter
+    {
+        
+        public static DateTimeOffset StartTime = DateTimeOffset.Now;
+        public static Stopwatch DedupeTimer = new Stopwatch();
+
+        private static void LogDedupe(string message)
+        {
+            PluginLog.LogDebug($"[DEDUPE] {message}");
+        }
+
+        public bool IsRecentlySent(string displayName, string chatText, SocketChannel socketChannel)
+        {
+            // check for duplicates before sending
+            // straight up copied from the previous bot, but I have no way to test this myself.
+            var cachedMessages = (socketChannel as SocketTextChannel).GetCachedMessages();
+            var recentMsg = cachedMessages.FirstOrDefault(msg => msg.Content == chatText);
+
+                
+            //if (this.plugin.Config.DuplicateCheckMS > 0 && recentMsg != null)
+            if (recentMsg != null)
+            {
+                long msgDiff = GetElapsedMs(recentMsg);
+                    
+                //if (msgDiff < this.plugin.Config.DuplicateCheckMS)
+                if (msgDiff < 5000)
+                {
+                    LogDedupe($"DIFF:{msgDiff}ms Skipping duplicate message: {chatText}");
+                    return true;
+                }
+                        
+            }
+                
+            LogDedupe($"Sending: {displayName}, {chatText}");
+            return false;
+
+            // the message to a list of recently sent messages. 
+            // If someone else sent the same thing at the same time
+            // both will need to be checked and the earlier timestamp kept
+            // while the newer one is removed
+            // refer to https://discord.com/channels/581875019861328007/684745859497590843/791207648619266060
+        }
+
+        public async Task Dedupe(SocketChannel socketChannel)
+        {
+            //GetElapsedMs(StartTime);
+            if (DedupeTimer.ElapsedMilliseconds < 5000)
+            {
+                if (!DedupeTimer.IsRunning) DedupeTimer.Start();
+                //LogDedupe("No-op");
+                return;
+            }
+            DedupeTimer.Restart();
+            
+            if (socketChannel is not SocketTextChannel socketTextChannel)
+            {
+                return;
+            }
+
+            var cachedMessages = socketTextChannel.GetCachedMessages();
+
+            var recentMessages = cachedMessages.Where(m => GetElapsedMs(m) < 10000);
+            var socketMessages = recentMessages as SocketMessage[] ?? recentMessages.ToArray();
+            var content = socketMessages.Select(m => m.Content);
+
+            LogDedupe("Dedupe cached messages");
+            LogDedupe($"- Total: {cachedMessages.Count()}");
+            LogDedupe($"- Recent: {socketMessages.Count()}");
+            LogDedupe($"- Content: {string.Join(", ", content)}");
+
+            for (var i = 0; i < socketMessages.Length; i++)
+            {
+                var recent = socketMessages[i];
+
+                for (var j = 0; j < socketMessages.Length; j++)
+                {
+                    if (i != j)
+                    {
+                        var other = socketMessages[j];
+
+                        if (IsDuplicate(recent, other))
+                        {
+                            await DeleteMostRecent(recent, other);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static long GetElapsedMs(DateTimeOffset timestamp)
+        {
+            return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - timestamp.ToUnixTimeMilliseconds();
+        }
+
+        private static long GetElapsedMs(SocketMessage message)
+        {
+            return GetElapsedMs(message.Timestamp);
+            //return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - message.Timestamp.ToUnixTimeMilliseconds();
+        }
+
+        private async Task DeleteMostRecent(SocketMessage recent, SocketMessage other)
+        {
+            if (recent.Timestamp > other.Timestamp)
+            {
+                await TryDeleteAsync(recent);
+            }
+            else
+            {
+                await TryDeleteAsync(other);
+            }
+        }
+
+        private static async Task TryDeleteAsync(SocketMessage message)
+        {
+            LogDedupe($"Delete: ({message.Author.Username}) {message.Content}");
+
+            // if (message.Author.IsBot)
+            // {
+               //  PluginLog.LogInformation($"AUTHOR IS BOT");
+               //  return;
+            // }
+
+            try
+            {
+                await message.DeleteAsync();
+            }
+            catch (Discord.Net.HttpException)
+            {
+                LogDedupe($"Message could not be deleted");
+            }
+        }
+
+
+        private const string GroupPrefix = "prefix"; 
+        private const string GroupSlug = "slug"; 
+        private const string GroupText = "text"; 
+        private static readonly Regex ExtractChatText = new Regex(@$"(?'{GroupPrefix}'.*)(?'{GroupSlug}'\[.+\]) (?'{GroupText}'.+)");
+        
+        private bool IsDuplicate(SocketMessage recent, SocketMessage other)
+        {
+            string left = recent.Content;
+            string right = other.Content;
+
+            bool notEmptyString = !(recent.Content.IsNullOrEmpty() && other.Content.IsNullOrEmpty());
+
+            //bool bothWebhook = recent.Author.IsWebhook && other.Author.IsWebhook;
+            const bool bothWebhook = true;
+
+            bool sameUser = recent.Author.Username == other.Author.Username;
+            //bool sameUser = true;
+            
+
+            bool differentId = recent.Id != other.Id;
+
+            string leftText = GetText(recent.Content);
+            string rightText = GetText(other.Content);
+
+            return notEmptyString && bothWebhook && sameUser && differentId && (leftText == rightText);
+        }
+
+        private static string GetText(string recentContent)
+        {
+            var matches = ExtractChatText.Match(recentContent);
+
+            return matches.Groups[GroupText].Value;
+        }
+    }
+}

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -122,6 +122,11 @@ namespace Dalamud.DiscordBridge
             //return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - message.Timestamp.ToUnixTimeMilliseconds();
         }
 
+        private static long DifferenceMs(DateTimeOffset left, DateTimeOffset right)
+        {
+            return left.ToUnixTimeMilliseconds() - right.ToUnixTimeMilliseconds();
+        }
+
         private async Task DeleteMostRecent(SocketMessage recent, SocketMessage other)
         {
             if (recent.Timestamp > other.Timestamp)
@@ -171,15 +176,17 @@ namespace Dalamud.DiscordBridge
             const bool bothWebhook = true;
 
             bool sameUser = recent.Author.Username == other.Author.Username;
+            LogDedupe($"USERS: {recent.Author.Username} //// {other.Author.Username}, {sameUser}");
             //bool sameUser = true;
-            
+
+            bool withinTime = Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp)) < 5000;
 
             bool differentId = recent.Id != other.Id;
 
             string leftText = GetText(recent.Content);
             string rightText = GetText(other.Content);
 
-            return notEmptyString && bothWebhook && sameUser && differentId && (leftText == rightText);
+            return notEmptyString && bothWebhook && sameUser && withinTime && differentId && (leftText == rightText);
         }
 
         private static string GetText(string recentContent)

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -48,7 +48,7 @@ namespace Dalamud.DiscordBridge
                 long msgDiff = GetElapsedMs(recentMsg);
                     
                 //if (msgDiff < this.plugin.Config.DuplicateCheckMS)
-                if (msgDiff < 5000)
+                if (msgDiff < 2000)
                 {
                     LogDedupe($"DIFF:{msgDiff}ms Skipping duplicate message: {chatText}");
                     return true;
@@ -69,7 +69,7 @@ namespace Dalamud.DiscordBridge
         public async Task Dedupe(SocketChannel socketChannel)
         {
             //GetElapsedMs(StartTime);
-            if (DedupeTimer.ElapsedMilliseconds < 5000)
+            if (DedupeTimer.ElapsedMilliseconds < 1000)
             {
                 if (!DedupeTimer.IsRunning) DedupeTimer.Start();
                 //LogDedupe("No-op");
@@ -125,7 +125,7 @@ namespace Dalamud.DiscordBridge
 
         private static long DifferenceMs(DateTimeOffset left, DateTimeOffset right)
         {
-            return left.ToUnixTimeMilliseconds() - right.ToUnixTimeMilliseconds();
+            return GetElapsedMs(left) - GetElapsedMs(right);
         }
 
         private async Task DeleteMostRecent(SocketMessage recent, SocketMessage other)
@@ -173,14 +173,15 @@ namespace Dalamud.DiscordBridge
 
             bool notEmptyString = !(recent.Content.IsNullOrEmpty() && other.Content.IsNullOrEmpty());
 
-            //bool bothWebhook = recent.Author.IsWebhook && other.Author.IsWebhook;
-            const bool bothWebhook = true;
+            bool bothWebhook = recent.Author.IsWebhook && other.Author.IsWebhook;
+            bothWebhook = true;
 
             bool sameUser = recent.Author.Username == other.Author.Username;
+            sameUser = true;
             LogDedupe($"USERS: {recent.Author.Username} //// {other.Author.Username}, {sameUser}");
-            //bool sameUser = true;
 
-            bool withinTime = Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp)) < 5000;
+            bool withinTime = Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp)) < 3000;
+            LogDedupe($"withinTime: {Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp))}ms");
 
             bool differentId = recent.Id != other.Id;
 

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -326,8 +326,8 @@ namespace Dalamud.DiscordBridge
 
             string leftText = GetText(recent.Content);
             string rightText = GetText(other.Content);
-            _logHelper.LogValue(leftText);
-            _logHelper.LogValue(rightText);
+            _logHelper.LogExpr(leftText);
+            _logHelper.LogExpr(rightText);
 
             var result = sameUser && differentId && (leftText == rightText);
             _logHelper.Pop($"(RETURN {result})");
@@ -336,11 +336,17 @@ namespace Dalamud.DiscordBridge
 
         private bool IsDuplicate(string leftDisplayName, string leftContent, string rightDisplayName, string rightContent)
         {
+            _logHelper.Push("COMPARE (SIMPLE)");
+            
             string leftChatText = GetText(leftContent);
             string rightChatText = GetText(rightContent);
 
-            return leftDisplayName == rightDisplayName &&
+            bool result = leftDisplayName == rightDisplayName &&
                    leftChatText == rightChatText;
+
+            _logHelper.Pop($"(RETURN {result})");
+            
+            return result;
         }
 
         private static string GetText(string recentContent)
@@ -362,7 +368,7 @@ namespace Dalamud.DiscordBridge
         private const string GroupPrefix = "prefix"; 
         private const string GroupSlug = "slug"; 
         private const string GroupChatText = "chatText"; 
-        private static readonly Regex ExtractChatText = new Regex(@$"(?'{GroupPrefix}'.*)(?'{GroupSlug}'\[.+\]) (?'{GroupChatText}'.+)");
+        private static readonly Regex ExtractChatText = new Regex(@$"(?'{GroupPrefix}'.*)\*\*\[(?'{GroupSlug}'.+)\]\*\* (?'{GroupChatText}'.+)");
         // (?'GroupPrefix'.*)\*?\*?\[(?'GroupSlug'.+)\]\*?\*? (?'GroupChatText'.+)
 
         private DateTimeOffset lastUpdate = DateTimeOffset.Now;

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -22,8 +22,6 @@ namespace Dalamud.DiscordBridge
         /// <param name="client">The socket client to monitor for duplicate messages.</param>
         public DuplicateFilter(DiscordSocketClient client)
         {
-            PluginLog.LogVerbose("[FILTER] Started!");
-            
             client.MessageReceived += OnMessageReceived;
         }
         
@@ -59,7 +57,7 @@ namespace Dalamud.DiscordBridge
             
             if (msgDiff < RecentIntervalMs)
             {
-                PluginLog.LogVerbose($"[FILTER]\n ALREADY SENT\n Filtered outgoing message.\n Threshold: {RecentIntervalMs}ms\n Diff: {msgDiff}ms\n Name: {displayName}\n Text: {chatText}");
+                PluginLog.LogVerbose($"[FILTER] Filtered outgoing message as duplicate. Threshold: {RecentIntervalMs}ms, Diff: {msgDiff}ms");
 
                 return true;
             }
@@ -143,8 +141,6 @@ namespace Dalamud.DiscordBridge
             {
                 await message.DeleteAsync();
                 //await message.AddReactionAsync(new Emoji("💥")); // useful for testing
-                
-                PluginLog.LogVerbose($"[FILTER]\n[DELETED]\n CHANNEL: {message.Channel}\n NAME: {message.Author.Username}\n CONTENT: {message.Content}");
                 
                 return true;
             }

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -116,11 +116,11 @@ namespace Dalamud.DiscordBridge
         
         public bool IsRecentlySent(string displayName, string chatText)
         {
-            //todo this is wrong because msg.Content needs to be parsed to get the chatText
             // check for duplicates before sending
             // straight up copied from the previous bot, but I have no way to test this myself.
             var recentMsg = _recentMessages.FirstOrDefault(msg =>
-                IsDuplicate(msg.Author.Username, msg.Content, displayName, chatText));
+                msg.Author.Username == displayName &&
+                GetChatText(msg.Content) == chatText);
 
             //if (this.plugin.Config.DuplicateCheckMS > 0 && recentMsg != null)
             if (recentMsg != null)
@@ -215,15 +215,10 @@ namespace Dalamud.DiscordBridge
         
         private static bool IsDuplicate(SocketMessage left, SocketMessage right)
         {
-            return IsDuplicate(left.Author.Username, left.Content, right.Author.Username, right.Content);
-        }
+            string leftChatText = GetChatText(left.Content);
+            string rightChatText = GetChatText(right.Content);
 
-        private static bool IsDuplicate(string leftDisplayName, string leftContent, string rightDisplayName, string rightContent)
-        {
-            string leftChatText = GetChatText(leftContent);
-            string rightChatText = GetChatText(rightContent);
-
-            return leftDisplayName == rightDisplayName &&
+            return left.Author.Username == right.Author.Username &&
                    leftChatText == rightChatText;
         }
 

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -199,9 +200,14 @@ namespace Dalamud.DiscordBridge
                 
                 return true;
             }
-            catch (Discord.Net.HttpException)
+            catch (Discord.Net.HttpException ex)
             {
-                PluginLog.LogVerbose($"Message for deletion not found: {message.Id}");
+                // 404 Not Found is expected if the message was already deleted.
+                // Otherwise, it's an unexpected error so rethrow.
+                if (ex.HttpCode != HttpStatusCode.NotFound)
+                {
+                    throw;
+                }
             }
             
             return false;

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -38,7 +38,8 @@ namespace Dalamud.DiscordBridge
             // check for duplicates before sending
             // straight up copied from the previous bot, but I have no way to test this myself.
             var cachedMessages = (socketChannel as SocketTextChannel).GetCachedMessages();
-            var recentMsg = cachedMessages.FirstOrDefault(msg => msg.Content == chatText);
+            var recentMsg = cachedMessages.FirstOrDefault(msg =>
+                IsDuplicate(msg.Author.Username, msg.Content, displayName, chatText));
 
                 
             //if (this.plugin.Config.DuplicateCheckMS > 0 && recentMsg != null)
@@ -187,6 +188,15 @@ namespace Dalamud.DiscordBridge
             string rightText = GetText(other.Content);
 
             return notEmptyString && bothWebhook && sameUser && withinTime && differentId && (leftText == rightText);
+        }
+
+        private bool IsDuplicate(string leftDisplayName, string leftContent, string rightDisplayName, string rightContent)
+        {
+            string leftChatText = GetText(leftContent);
+            string rightChatText = GetText(rightContent);
+
+            return leftDisplayName == rightDisplayName &&
+                   leftChatText == rightChatText;
         }
 
         private static string GetText(string recentContent)

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -111,7 +111,9 @@ namespace Dalamud.DiscordBridge
             _logHelper.LogExpr(message.Author.Username);
             _logHelper.LogExpr(message.Content);
 
-            if (recentMessages.All(m => m.Id != message.Id))
+            if (recentMessages.All(m => m.Id != message.Id) &&
+                message.Author.IsWebhook &&
+                !message.Content.IsNullOrEmpty())
             {
                 recentMessages.Add(message);
                 
@@ -312,28 +314,22 @@ namespace Dalamud.DiscordBridge
         private bool IsDuplicate(SocketMessage recent, SocketMessage other)
         {
             _logHelper.Push("COMPARE");
-            
-            string left = recent.Content;
-            string right = other.Content;
-
-            bool notEmptyString = !(recent.Content.IsNullOrEmpty() && other.Content.IsNullOrEmpty());
-
-            bool bothWebhook = recent.Author.IsWebhook && other.Author.IsWebhook;
-            //bothWebhook = true;
 
             bool sameUser = recent.Author.Username == other.Author.Username;
             //sameUser = true;
-            _logHelper.Log($"sameUser: {recent.Author.Username} //// {other.Author.Username}, {sameUser}");
+            //_logHelper.Log($"sameUser: {recent.Author.Username} //// {other.Author.Username}, {sameUser}");
 
-            bool withinTime = Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp)) < ComparisonIntervalMs;
-            _logHelper.Log($"withinTime: {Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp))}ms");
+            //bool withinTime = Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp)) < ComparisonIntervalMs;
+            //_logHelper.Log($"withinTime: {Math.Abs(DifferenceMs(recent.Timestamp, other.Timestamp))}ms");
 
             bool differentId = recent.Id != other.Id;
 
             string leftText = GetText(recent.Content);
             string rightText = GetText(other.Content);
+            _logHelper.LogValue(leftText);
+            _logHelper.LogValue(rightText);
 
-            var result = notEmptyString && bothWebhook && sameUser && withinTime && differentId && (leftText == rightText);
+            var result = sameUser && differentId && (leftText == rightText);
             _logHelper.Pop($"(RETURN {result})");
             return result;
         }

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -26,7 +26,7 @@ namespace Dalamud.DiscordBridge
         {
             LogDedupe($"Add message: {message.Author.Username} {message.Content}");
 
-            if (!recentMessages.Contains(message))
+            if (recentMessages.All(m => m.Id != message.Id))
             {
 
                 recentMessages.Add(message);                
@@ -224,6 +224,7 @@ namespace Dalamud.DiscordBridge
         private const string GroupSlug = "slug"; 
         private const string GroupChatText = "chatText"; 
         private static readonly Regex ExtractChatText = new Regex(@$"(?'{GroupPrefix}'.*)(?'{GroupSlug}'\[.+\]) (?'{GroupChatText}'.+)");
+        // (?'GroupPrefix'.*)\*?\*?\[(?'GroupSlug'.+)\]\*?\*? (?'GroupChatText'.+)
 
         private DateTimeOffset startTime = DateTimeOffset.Now;
         

--- a/Dalamud.DiscordBridge/Plugin.cs
+++ b/Dalamud.DiscordBridge/Plugin.cs
@@ -177,7 +177,7 @@ namespace Dalamud.DiscordBridge
 
             this.State.CfPop -= this.ClientStateOnCfPop;
 
-            this.Interface.Dispose();
+            //this.Interface.Dispose();
         }
 
         public void Dispose()

--- a/Dalamud.DiscordBridge/PluginUI.cs
+++ b/Dalamud.DiscordBridge/PluginUI.cs
@@ -97,7 +97,7 @@ namespace Dalamud.DiscordBridge
 
                 this.plugin.Discord.Dispose();
                 this.plugin.Discord = new DiscordHandler(this.plugin);
-                this.plugin.Discord.Start();
+                _ = this.plugin.Discord.Start();
             }
         }
     }

--- a/Dalamud.DiscordBridge/SpecialCharsHandler.cs
+++ b/Dalamud.DiscordBridge/SpecialCharsHandler.cs
@@ -38,7 +38,7 @@ namespace Dalamud.DiscordBridge
             return returnString.ToString();
         }
 
-        public async Task TryFindEmote(DiscordSocketClient socketClient)
+        public void TryFindEmote(DiscordSocketClient socketClient)
         {
             foreach (var guild in socketClient.Guilds)
             {


### PR DESCRIPTION
This uses the approach in #1 while checking that messages match by channel, slug, username, and chat text. Custom chat type names and linkshells have to match between bots, but anyone using this feature will be coordinating with others anyway. Prefixes for chat types can differ, which is useful to tell which bot is which.

This was tested with help from @hmm-norah. Our stress test used three clients sending to the same channel. Reactions instead of deletions can be used to show visually how it works:

![image](https://user-images.githubusercontent.com/99750849/182307512-ed045ff9-d392-4d0d-8db2-75846136261e.png)

One limitation is that when using commands, every bot that isn't yours will respond with an error message. Even so the feature works and it can be fixed later.