### PR TITLE
Handle Duplicate Messages

### DIFF
--- a/Dalamud.DiscordBridge/Configuration.cs
+++ b/Dalamud.DiscordBridge/Configuration.cs
@@ -11,7 +11,7 @@ namespace Dalamud.DiscordBridge
     {
         public int Version { get; set; }
 
-        public long DuplicateCheckMS { get; set; } = 0;
+        public long DuplicateCheckMS { get; set; } = 5000;
 
         [JsonIgnore] private DalamudPluginInterface pluginInterface;
 

--- a/Dalamud.DiscordBridge/ContentParser.cs
+++ b/Dalamud.DiscordBridge/ContentParser.cs
@@ -1,0 +1,57 @@
+using System.Text.RegularExpressions;
+using Dalamud.Utility;
+
+namespace Dalamud.DiscordBridge
+{
+    /// <summary>
+    /// Parses a content string so that messages received externally can be compared.
+    /// </summary>
+    public class ContentParser
+    {
+        /// <summary>
+        /// Construct a <see cref="ContentParser"/>, parsing the given content string.
+        /// </summary>
+        /// <param name="content">The content string to parse.</param>
+        public ContentParser(string content)
+        {
+            match = Parse.Match(content);
+        }
+
+        /// <summary>
+        /// The user-defined prefix for the slug.
+        /// </summary>
+        public string Prefix => match.Groups[PrefixGroup].Value;
+        
+        /// <summary>
+        /// The slug for the chat kind.
+        /// </summary>
+        public string Slug => match.Groups[SlugGroup].Value;
+        
+        /// <summary>
+        /// The relevant text from the in-game chat line.
+        /// </summary>
+        public string Text => match.Groups[TextGroup].Value;
+
+        /// <summary>
+        /// Parse the text from a content string.
+        /// </summary>
+        /// <param name="content">The content string to parse.</param>
+        /// <returns>The relevant text from the in-game chat line.</returns>
+        public static string ParseText(string content)
+        {
+            var contentParser = new ContentParser(content);
+
+            string result = contentParser.Text;
+            
+            return result.IsNullOrEmpty() ? content : result;
+        }
+        
+        private const string PrefixGroup = "prefix";
+        private const string SlugGroup = "slug";
+        private const string TextGroup = "text";
+        
+        private static readonly Regex Parse = new(@$"(?'{PrefixGroup}'.*)\*\*\[(?'{SlugGroup}'.+)\]\*\* (?'{TextGroup}'.+)");
+
+        private readonly Match match;
+    }
+}

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Dalamud.DiscordBridge.Model;
 using Dalamud.DiscordBridge.XivApi;
 using Dalamud.Game.Text;
 using Dalamud.Logging;
+using Dalamud.Utility;
 using Discord;
 using Discord.Net.Providers.WS4Net;
 using Discord.Webhook;
@@ -20,6 +24,8 @@ namespace Dalamud.DiscordBridge
 {
     public class DiscordHandler : IDisposable
     {
+        private readonly DuplicateFilter duplicateFilter;
+        
         private readonly DiscordSocketClient socketClient;
         private readonly SpecialCharsHandler specialChars;
 
@@ -104,6 +110,8 @@ namespace Dalamud.DiscordBridge
             });
             this.socketClient.Ready += SocketClientOnReady;
             this.socketClient.MessageReceived += SocketClientOnMessageReceived;
+            
+            this.duplicateFilter = new DuplicateFilter(this.plugin, this.socketClient);
         }
 
         public async Task Start()
@@ -134,12 +142,14 @@ namespace Dalamud.DiscordBridge
             PluginLog.Verbose("DiscordHandler START!!");
         }
 
-        private async Task SocketClientOnReady()
+        private Task SocketClientOnReady()
         {
             this.State = DiscordState.Ready;
-            await this.specialChars.TryFindEmote(this.socketClient);
+            this.specialChars.TryFindEmote(this.socketClient);
 
             PluginLog.Verbose("DiscordHandler READY!!");
+            
+            return Task.CompletedTask;
         }
 
         private async Task SocketClientOnMessageReceived(SocketMessage message)
@@ -960,29 +970,11 @@ namespace Dalamud.DiscordBridge
                 {
                     var webhookClient = await GetOrCreateWebhookClient(socketChannel);
 
-                    // check for duplicates before sending
-                    // straight up copied from the previous bot, but I have no way to test this myself.
-                    var recentMessages = (socketChannel as SocketTextChannel).GetCachedMessages();
-                    var recentMsg = recentMessages.FirstOrDefault(msg => msg.Content == messageContent);
-
-                    if (this.plugin.Config.DuplicateCheckMS > 0 && recentMsg != null)
+                    if (duplicateFilter.CheckAlreadySent(socketChannel, slug: chatTypeText, displayName, chatText: message))
                     {
-                        long msgDiff = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - recentMsg.Timestamp.ToUnixTimeMilliseconds();
-
-                        if (msgDiff < this.plugin.Config.DuplicateCheckMS)
-                        {
-                            PluginLog.Log($"[IN TESTING]\n DIFF:{msgDiff}ms Skipping duplicate message: {messageContent}");
-                            return;
-                        }
-
+                        continue;
                     }
-
-                    // the message to a list of recently sent messages. 
-                    // If someone else sent the same thing at the same time
-                    // both will need to be checked and the earlier timestamp kept
-                    // while the newer one is removed
-                    // refer to https://discord.com/channels/581875019861328007/684745859497590843/791207648619266060
-
+                    
                     await webhookClient.SendMessageAsync(
                         messageContent, username: displayName, avatarUrl: avatarUrl,
                         allowedMentions: new AllowedMentions(AllowedMentionTypes.Roles | AllowedMentionTypes.Users | AllowedMentionTypes.None)

--- a/Dalamud.DiscordBridge/DuplicationFilter.cs
+++ b/Dalamud.DiscordBridge/DuplicationFilter.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using Discord.WebSocket;
+
+using Dalamud.Logging;
+using Dalamud.Utility;
+
+namespace Dalamud.DiscordBridge
+{
+    /// <summary>
+    /// Dedupes already posted messages whenever a message is received.
+    /// </summary>
+    public class DuplicateFilter
+    {
+        /// <summary>
+        /// Constructs a <see cref="DuplicateFilter"/> to dedupe messages for the given socket client.
+        /// </summary>
+        /// <param name="plugin"></param>
+        /// <param name="client">The socket client to monitor for duplicate messages.</param>
+        public DuplicateFilter(Plugin plugin, DiscordSocketClient client)
+        {
+            this.plugin = plugin;
+            
+            client.MessageReceived += OnMessageReceived;
+        }
+        
+        #region Methods
+
+        /// <summary>
+        /// Check if an in-game chat was already sent to the server, either by this client or another.
+        /// </summary>
+        /// <param name="channel">The channel to be the destination.</param>
+        /// <param name="slug">The identifier for the chat type.</param>
+        /// <param name="displayName">The name of the player who sent the chat message.</param>
+        /// <param name="chatText">The relevant text of the chat message.</param>
+        /// <returns>Whether the chat was recently sent and should be prevented.</returns>
+        public bool CheckAlreadySent(SocketChannel channel, string slug, string displayName, string chatText)
+        {
+            // Get the first message that duplicates the name and text for consideration.
+            var recentMsg = recentMessages.FirstOrDefault(msg =>
+            {
+                var contentParser = new ContentParser(msg.Content);
+                
+                return msg.Channel.Id == channel.Id &&
+                       msg.Author.Username == displayName &&
+                       contentParser.Slug == slug &&
+                       contentParser.Text == chatText;
+            });
+
+            if (recentMsg == null)
+            {
+                return false;
+            }
+            
+            long msgDiff = GetAgeMs(recentMsg);
+            
+            if (msgDiff < plugin.Config.DuplicateCheckMS)
+            {
+                PluginLog.LogVerbose($"[FILTER] Filtered outgoing message as duplicate. Diff: {msgDiff}ms, Threshold: {plugin.Config.DuplicateCheckMS}ms");
+
+                return true;
+            }
+
+            return false;
+        }
+
+        #endregion
+        
+        #region Private Functions
+
+        private async Task OnMessageReceived(SocketMessage message)
+        {
+            AddRecent(message);
+            
+            await Dedupe();
+        }
+
+        private void AddRecent(SocketMessage message)
+        {
+            // The message should be from a webhook and have a content string. 
+            if (!message.Author.IsWebhook || message.Content.IsNullOrEmpty())
+            {
+                return;
+            }
+            
+            // Add the message if it's not already in the recent messages list.
+            recentMessages.Add(message);
+        }
+        
+        private async Task Dedupe()
+        {
+            // Remove for consideration any message that's over the age threshold.
+            var filtered = recentMessages
+                .Where(m => GetAgeMs(m) < plugin.Config.DuplicateCheckMS)
+                .ToArray(); // Convert to array to avoid multiple enumeration below.
+
+            // Holds deleted messages so that they can be removed from recents later.
+            var deleted = new HashSet<SocketMessage>();
+            
+            // Compare every message to every other message to check for duplicates.
+            // - there's probably a linq way to do this, but would it really be better
+            for (var outerIdx = 0; outerIdx < filtered.Length; outerIdx++)
+            {
+                var recent = filtered[outerIdx];
+
+                for (var innerIdx = outerIdx + 1; innerIdx < filtered.Length; innerIdx++)
+                {
+                    var other = filtered[innerIdx];
+                    
+                    if (IsDuplicate(recent, other))
+                    {
+                        SocketMessage mostRecent = await DeleteMostRecent(recent, other);
+
+                        deleted.Add(mostRecent);
+                    }
+                }
+            }
+
+            // Rebuild recent messages to exclude old messages and deleted messages.
+            recentMessages = new(filtered.Except(deleted));
+        }
+        
+        /// <returns>The most recent of the two messages.</returns>
+        private async Task<SocketMessage> DeleteMostRecent(SocketMessage left, SocketMessage right)
+        {
+            bool leftIsNewer = left.Timestamp.Offset > right.Timestamp.Offset;
+            
+            SocketMessage target = leftIsNewer ? left : right;
+            
+            _ = await TryDeleteAsync(target);
+            
+            return target;
+        }
+
+        /// <returns>Whether the message existed on the server and was deleted.</returns>
+        private static async Task<bool> TryDeleteAsync(SocketMessage message)
+        {
+            try
+            {
+                await message.DeleteAsync();
+                //await message.AddReactionAsync(new Emoji("💥")); // useful for testing
+                
+                return true;
+            }
+            catch (Discord.Net.HttpException ex)
+            {
+                // Rethrow unless 404 came back.
+                // 404 is expected if the message was already deleted.
+                if (ex.HttpCode != HttpStatusCode.NotFound)
+                {
+                    PluginLog.LogError($"[FILTER] Unexpected exception when attempting to delete a message.");
+                    
+                    throw;
+                }
+            }
+            
+            return false;
+        }
+        
+        private static bool IsDuplicate(SocketMessage left, SocketMessage right)
+        {
+            var leftContent = new ContentParser(left.Content);
+            var rightContent = new ContentParser(right.Content);
+            
+            return left.Channel.Id == right.Channel.Id &&
+                   leftContent.Slug == rightContent.Slug &&
+                   left.Author.Username == right.Author.Username &&
+                   leftContent.Text == rightContent.Text;
+        }
+
+        private static long GetAgeMs(SocketMessage message)
+        {
+            return GetElapsedMs(message.Timestamp);
+        }
+        
+        private static long GetElapsedMs(DateTimeOffset timestamp)
+        {
+            return DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - timestamp.ToUnixTimeMilliseconds();
+        }
+        
+        #endregion
+        
+        #region Private Data
+
+        private readonly Plugin plugin;
+        
+        private HashSet<SocketMessage> recentMessages = new();
+
+        #endregion
+    }
+}

--- a/Dalamud.DiscordBridge/PluginUI.cs
+++ b/Dalamud.DiscordBridge/PluginUI.cs
@@ -97,7 +97,7 @@ namespace Dalamud.DiscordBridge
 
                 this.plugin.Discord.Dispose();
                 this.plugin.Discord = new DiscordHandler(this.plugin);
-                this.plugin.Discord.Start();
+                _ = this.plugin.Discord.Start();
             }
         }
     }

--- a/Dalamud.DiscordBridge/SpecialCharsHandler.cs
+++ b/Dalamud.DiscordBridge/SpecialCharsHandler.cs
@@ -38,7 +38,7 @@ namespace Dalamud.DiscordBridge
             return returnString.ToString();
         }
 
-        public async Task TryFindEmote(DiscordSocketClient socketClient)
+        public void TryFindEmote(DiscordSocketClient socketClient)
         {
             foreach (var guild in socketClient.Guilds)
             {


### PR DESCRIPTION
This uses the approach in #1 while checking that messages match by channel, slug, username, and chat text. Custom chat type names and linkshells have to match between bots, but anyone using this feature will be coordinating with others anyway. Prefixes for chat types can differ, which is useful to tell which bot is which.

This was tested with help from @hmm-norah. Our stress test used three clients sending to the same channel. Reactions instead of deletions can be used to show visually how it works:

![image](https://user-images.githubusercontent.com/99750849/182323539-9581d647-495f-426e-bf94-bf45a81837d0.png)

One limitation is that when using commands, every bot that isn't yours will respond with an error message. Even so the feature works and it can be fixed later.