### PR TITLE
Prevent losing channel config if a chat is being sent while the plugin is reloading

### DIFF
--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -846,6 +846,7 @@ namespace Dalamud.DiscordBridge
 
             message = this.specialChars.TransformToUnicode(message);
 
+            bool characterSearchFailed = false;
             
             try
             {
@@ -888,11 +889,20 @@ namespace Dalamud.DiscordBridge
                             else
                             {
                                 PluginLog.Verbose($"Searching lodestone for {playerCacheName}");
-                                lschar = await lodestoneClient.SearchCharacter(new CharacterSearchQuery()
+
+                                var searchPage = await lodestoneClient.SearchCharacter(new CharacterSearchQuery
                                 {
                                     CharacterName = senderName,
                                     World = senderWorld,
-                                }).Result.Results.FirstOrDefault(result => result.Name == senderName).GetCharacter();
+                                });
+
+                                var matchingEntry = searchPage.Results.FirstOrDefault(result => result.Name == senderName);
+                                if (matchingEntry == null)
+                                {
+                                    break;
+                                }
+                                
+                                lschar = await matchingEntry.GetCharacter();
 
                                 CachedResponses.TryAdd(playerCacheName, lschar);
                                 PluginLog.Verbose($"Adding cached data for {lschar.Name} {lschar.Avatar}");
@@ -916,7 +926,8 @@ namespace Dalamud.DiscordBridge
                 {
                     PluginLog.Error(ex, $"Cannot fetch XIVAPI character search for {senderName} on {senderWorld}");
                 }
-                    
+                
+                characterSearchFailed = true;
             }
 
             var displayName = senderName + (string.IsNullOrEmpty(senderWorld) || string.IsNullOrEmpty(senderName)
@@ -936,13 +947,15 @@ namespace Dalamud.DiscordBridge
                 {
                     PluginLog.Error("Could not find channel {0} for {1}", channelConfig.Key, chatType);
 
-                    var channelConfigs = this.plugin.Config.ChannelConfigs;
-                    channelConfigs.Remove(channelConfig.Key);
-                    this.plugin.Config.ChannelConfigs = channelConfigs;
+                    if (!characterSearchFailed)
+                    {
+                        var channelConfigs = this.plugin.Config.ChannelConfigs;
+                        channelConfigs.Remove(channelConfig.Key);
+                        this.plugin.Config.ChannelConfigs = channelConfigs;
 
-
-                    PluginLog.Log("Removing channel {0}'s config because it no longer exists or cannot be accessed.", channelConfig.Key);
-                    this.plugin.Config.Save();
+                        PluginLog.Log("Removing channel {0}'s config because it no longer exists or cannot be accessed.", channelConfig.Key);
+                        this.plugin.Config.Save();
+                    }
                     
                     continue;
                 }


### PR DESCRIPTION
If chats are being sent while the plugin is reloading, there's a chance for Lodestone character search and DiscordSocketClient to fail. When this happens, SendChatEvent() thinks channel configs are invalid and removes them. This change also prevents two possible NREs during character search.

I ran into this while working on #19. It's more likely to happen for devs who are frequently reloading the plugin, but it's still good to fix.

```C#
2022-08-02 22:37:37.133 -05:00 [ERR] [Dalamud.DiscordBridge] Cannot fetch XIVAPI character search for _
System.NullReferenceException: Object reference not set to an instance of an object.
   at Dalamud.DiscordBridge.DiscordHandler.SendChatEvent(String message, String senderName, String senderWorld, XivChatType chatType, String avatarUrl) in C:\dev\projects\xiv\squidmade\Dalamud.DiscordBridge\Dalamud.DiscordBridge\DiscordHandler.cs:line 900
2022-08-02 22:37:37.134 -05:00 [ERR] [Dalamud.DiscordBridge] Could not find channel 1002074907502452907 for "CrossLinkShell3"
2022-08-02 22:37:37.139 -05:00 [INF] [Dalamud.DiscordBridge] Removing channel 1002074907502452907's config because it no longer exists or cannot be accessed.
2022-08-02 22:37:37.141 -05:00 [ERR] [Dalamud.DiscordBridge] Could not find channel 937131042383470642 for "CrossLinkShell3"
2022-08-02 22:37:37.141 -05:00 [INF] [Dalamud.DiscordBridge] Removing channel 937131042383470642's config because it no longer exists or cannot be accessed.
```